### PR TITLE
Added support for custom keymaps, added support for yaml configuration and refactored parts to modern C++23

### DIFF
--- a/.ccls
+++ b/.ccls
@@ -1,2 +1,0 @@
-clang++
-%cpp -std=c++20 -D_POSIX_C_SOURCE=199309L -O3 -g -Wall -Wextra -Wno-type-limits

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-.ccls-cache
-*.swp
-interception-vimproved
+*
+!.gitignore
+!README.md
+!LICENSE
+!Makefile
+!interception-vimproved.cpp

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 !README.md
 !LICENSE
 !Makefile
+!meson.build
+!config.yaml
 !interception-vimproved.cpp

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -std=c++20 -D_POSIX_C_SOURCE=199309L -O3 -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-type-limits
+CXXFLAGS += -std=c++2b -D_POSIX_C_SOURCE=199309L -O3 -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-type-limits
 TIMEOUT ?= 10
 
 INSTALL_FILE := /opt/interception/interception-vimproved

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,22 @@
-CXXFLAGS += -std=c++2b -D_POSIX_C_SOURCE=199309L -O3 -g -Wall -Wextra -Werror -Wno-unused-parameter -Wno-type-limits
-TIMEOUT ?= 10
+PROG_NAME = interception-vimproved
+BUILD_DIR = build
+INSTALL_DIR = /opt/interception
+TARGET = $(BUILD_DIR)/$(PROG_NAME)
+INSTALL_FILE = $(INSTALL_DIR)/$(PROG_NAME)
 
-INSTALL_FILE := /opt/interception/interception-vimproved
-
-# the build target executable:
-TARGET = interception-vimproved
-
-all: $(TARGET)
-
-$(TARGET): $(TARGET).cpp
-	$(CXX) $(CXXFLAGS) -o $(TARGET) $(TARGET).cpp
-
-.PHONY: clean
-clean:
-	rm -f $(TARGET) $(TARGET).o
+.PHONY: all
+all: build
 
 .PHONY: build
 build:
-	g++ -o interception-vimproved interception-vimproved.cpp
+	meson build
+	ninja -C build
 
 .PHONY: install
-install:
-	# If you have run `make test` then do not forget to run `make clean` after. Otherwise you may install with debug logs on.
+install: build
 	install -D --strip -T $(TARGET) $(INSTALL_FILE)
 
-.PHONY: test
-test:
-	CXXFLAGS=-DVERBOSE make
-	make install
-	timeout $(TIMEOUT) udevmon -c /etc/udevmon.yaml
+.PHONY: clean
+clean:
+	rm -rf $(BUILD_DIR)
+	rm -f $(INSTALL_FILE)

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,194 @@
+  # special chars
+- from: KEY_E
+  to: KEY_ESC
+
+# alternative syntax
+- {from: KEY_D, to: KEY_DELETE}
+
+# possibly even
+- layer: KEY_SPACE
+  from: KEY_B
+  to: KEY_BACKSPACE
+
+  # vim home row
+- from: KEY_H
+  to: KEY_LEFT
+
+- from: KEY_J
+  to: KEY_DOWN
+
+- from: KEY_K
+  to: KEY_UP
+
+- from: KEY_L
+  to: KEY_RIGHT
+
+  # vim above home row
+- from: KEY_Y
+  to: KEY_HOME
+
+- from: KEY_U
+  to: KEY_PAGEDOWN
+
+- from: KEY_I
+  to: KEY_PAGEUP
+
+- from: KEY_O
+  to: KEY_END
+
+  # number row to F keys
+- from: KEY_1
+  to: KEY_F1
+
+- from: KEY_2
+  to: KEY_F2
+
+- from: KEY_3
+  to: KEY_F3
+
+- from: KEY_4
+  to: KEY_F4
+
+- from: KEY_5
+  to: KEY_F5
+
+- from: KEY_6
+  to: KEY_F6
+
+- from: KEY_7
+  to: KEY_F7
+
+- from: KEY_8
+  to: KEY_F8
+
+- from: KEY_9
+  to: KEY_F9
+
+- from: KEY_0
+  to: KEY_F10
+
+- from: KEY_MINUS
+  to: KEY_F11
+
+- from: KEY_EQUAL
+  to: KEY_F12
+
+
+  # xf86 audio
+- from: KEY_M
+  to: KEY_MUTE
+
+- from: KEY_COMMA
+  to: KEY_VOLUMEDOWN
+
+- from: KEY_DOT
+  to: KEY_VOLUMEUP
+
+
+  # mouse navigation
+- from: BTN_LEFT
+  to: BTN_BACK
+
+- from: BTN_RIGHT
+  to: BTN_FORWARD
+
+
+  # special chars
+- from: KEY_E
+  to: KEY_ESC
+
+- from: KEY_D
+  to: KEY_DELETE
+
+- from: KEY_B
+  to: KEY_BACKSPACE
+
+  # vim home row
+- from: KEY_H
+  to: KEY_LEFT
+
+- from: KEY_J
+  to: KEY_DOWN
+
+- from: KEY_K
+  to: KEY_UP
+
+- from: KEY_L
+  to: KEY_RIGHT
+
+  # vim above home row
+- from: KEY_Y
+  to: KEY_HOME
+
+- from: KEY_U
+  to: KEY_PAGEDOWN
+
+- from: KEY_I
+  to: KEY_PAGEUP
+
+- from: KEY_O
+  to: KEY_END
+
+
+  # number row to F keys
+- from: KEY_1
+  to: KEY_F1
+
+- from: KEY_2
+  to: KEY_F2
+
+- from: KEY_3
+  to: KEY_F3
+
+- from: KEY_4
+  to: KEY_F4
+
+- from: KEY_5
+  to: KEY_F5
+
+- from: KEY_6
+  to: KEY_F6
+
+- from: KEY_7
+  to: KEY_F7
+
+- from: KEY_8
+  to: KEY_F8
+
+- from: KEY_9
+  to: KEY_F9
+
+- from: KEY_0
+  to: KEY_F10
+
+- from: KEY_MINUS
+  to: KEY_F11
+
+- from: KEY_EQUAL
+  to: KEY_F12
+
+
+  # xf86 audio
+- from: KEY_M
+  to: KEY_MUTE
+
+- from: KEY_COMMA
+  to: KEY_VOLUMEDOWN
+
+- from: KEY_DOT
+  to: KEY_VOLUMEUP
+
+
+  # mouse navigation
+- from: BTN_LEFT
+  to: BTN_BACK
+
+- from: BTN_RIGHT
+  to: BTN_FORWARD
+
+  # FIXME: this is not working
+  # to: even though `wev` says keycode 99 is Print
+
+  # PrtSc -> Context Menu
+- from: KEY_SYSRQ
+  to: KEY_CONTEXT_MENU

--- a/interception-vimproved.cpp
+++ b/interception-vimproved.cpp
@@ -13,7 +13,7 @@
 
 using Event = input_event;
 using KeyCode = unsigned short;
-using Mapping = std::pair<unsigned char, unsigned char>;
+using Mapping = std::pair<KeyCode, KeyCode>;
 
 const auto KEY_STROKE_UP = 0;
 const auto KEY_STROKE_DOWN = 1;

--- a/interception-vimproved.cpp
+++ b/interception-vimproved.cpp
@@ -7,9 +7,12 @@
 #include <unordered_map>
 #include <vector>
 #include <cstdlib>
+
 #include <unistd.h>
 #include <filesystem>
 #include <linux/input.h>
+
+#include <yaml-cpp/yaml.h>
 
 using Event = input_event;
 using KeyCode = unsigned short;
@@ -536,13 +539,12 @@ auto initInterceptedKeys(const std::vector<Mapping>& mappings) -> std::vector<In
 auto read_mappings_or_default(int argc, char** argv) -> std::vector<Mapping> {
   if (argc < 2) return DEFAULT_MAPPINGS;
   try {
-    auto file = std::ifstream(argv[1]);
+    auto config = YAML::LoadFile(argv[1]);
     auto mappings = std::vector<Mapping>();
-    for (auto line = std::string(); std::getline(file, line);) {
-      auto from = std::string();
-      auto to = std::string();
-      std::istringstream(line) >> from >> to;
-      mappings.push_back(Mapping{KEYS.at(from), KEYS.at(to)});
+    for (const auto& mapping : config) {
+      auto from = KEYS.at(mapping["from"].as<std::string>());
+      auto to = KEYS.at(mapping["to"].as<std::string>());
+      mappings.push_back({from, to});
     }
     return mappings;
   } catch (...) {

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,14 @@
+project('interception-vimproved', 'cpp')
+
+add_project_arguments(
+  '--std=c++20', '-O3', '-g',
+  '-Wall', '-Wextra', '-Wpedantic', '-Werror',
+  '-Wno-unused-parameter', '-Wno-type-limits',
+  language: 'cpp'
+)
+
+executable(
+  'interception-vimproved',
+  'interception-vimproved.cpp',
+  dependencies: dependency('yaml-cpp')
+)


### PR DESCRIPTION
Refactorings:
- Update syntax to modern C++23
- Use typealiases
- Use modern trailing return type function definition syntax
- Reduce pointer usages
- Eliminate `push_backs` by using constructors
- Eliminate `using namespace std` littering
- Eliminate duplication of typenames using auto
- Eliminate deletes at end of main
- Eliminate unnecessary heap allocations
- Eliminate unbraced if statements

Feature(custom keymaps):
- use a filepath as the single commandline argument to load a custom keymap
- syntax is the same as in the source: use the names of the keys as in the source
- each line should contain two key names, space-seperated
- the mapping maps the key on the left to the key on the right