### PR TITLE
Change "build" target to not be phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ CONFIG = config.yaml
 .PHONY: all
 all: build
 
-.PHONY: build
-build:
+build: build/interception-vimproved
 	meson build
 	ninja -C build
 


### PR DESCRIPTION
This change makes the "build" target not phony, which means that `make
install` won't build if it doesn't have to.

This allows running `make install` as a root user that doesn't know
where to find meson.