### PR TITLE
Fix Makefile to make it work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ CONFIG = config.yaml
 .PHONY: all
 all: build
 
-build: build/interception-vimproved
-	meson build
+build: 
+	meson setup build
 	ninja -C build
 
 .PHONY: install


### PR DESCRIPTION
It failed to compile with make complaining about non-existent rule for "build/interception-vimproved requiered for build".
Simply removing it from build requirements fixed the issue and did not affect other parts.

Also I got rid of this warning, while I'm here:
a
`WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.`